### PR TITLE
`useTracktor`

### DIFF
--- a/.docz/app/db.json
+++ b/.docz/app/db.json
@@ -3,7 +3,7 @@
     "title": "react-tracktor 🚜",
     "description": "A React render prop to gradually build tracking data down the render tree.",
     "menu": [],
-    "version": "2.0.0-0",
+    "version": "2.0.0-1",
     "repository": "https://github.com/mkaradeniz/react-tracktor",
     "native": false,
     "codeSandbox": false,
@@ -132,77 +132,6 @@
       }
     },
     {
-      "key": "docs/TracktorProvider.mdx",
-      "value": {
-        "name": "<TracktorProvider />",
-        "id": "47f8aae2c3aa6a63cde34d0a3a71f57f",
-        "filepath": "docs/TracktorProvider.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/TracktorProvider.mdx",
-        "slug": "docs-tracktor-provider",
-        "route": "/docs-tracktor-provider",
-        "menu": "",
-        "headings": [
-          {
-            "slug": "tracktorprovider-",
-            "depth": 1,
-            "value": "<TracktorProvider />"
-          },
-          {
-            "slug": "props",
-            "depth": 2,
-            "value": "Props"
-          },
-          {
-            "slug": "usage",
-            "depth": 2,
-            "value": "Usage"
-          }
-        ]
-      }
-    },
-    {
-      "key": "docs/UseTracktor.mdx",
-      "value": {
-        "name": "useTracktor()",
-        "id": "830591f9b63d4cefe7a0ea863f9d496e",
-        "filepath": "docs/UseTracktor.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/UseTracktor.mdx",
-        "slug": "docs-use-tracktor",
-        "route": "/docs-use-tracktor",
-        "menu": "",
-        "headings": []
-      }
-    },
-    {
-      "key": "docs/index.mdx",
-      "value": {
-        "name": "react-tracktor",
-        "route": "/",
-        "id": "73498ad0e1e62a714b08085d318f9de1",
-        "filepath": "docs/index.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/index.mdx",
-        "slug": "docs-index",
-        "menu": "",
-        "headings": [
-          {
-            "slug": "react-tracktor-",
-            "depth": 1,
-            "value": "react-tracktor 🚜"
-          },
-          {
-            "slug": "caveats",
-            "depth": 2,
-            "value": "Caveats"
-          },
-          {
-            "slug": "installation",
-            "depth": 2,
-            "value": "Installation"
-          }
-        ]
-      }
-    },
-    {
       "key": "docs/Tracktor.mdx",
       "value": {
         "name": "<Tracktor />",
@@ -257,6 +186,103 @@
             "slug": "intersectionwrapper",
             "depth": 3,
             "value": "intersectionWrapper"
+          }
+        ]
+      }
+    },
+    {
+      "key": "docs/TracktorProvider.mdx",
+      "value": {
+        "name": "<TracktorProvider />",
+        "id": "47f8aae2c3aa6a63cde34d0a3a71f57f",
+        "filepath": "docs/TracktorProvider.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/TracktorProvider.mdx",
+        "slug": "docs-tracktor-provider",
+        "route": "/docs-tracktor-provider",
+        "menu": "",
+        "headings": [
+          {
+            "slug": "tracktorprovider-",
+            "depth": 1,
+            "value": "<TracktorProvider />"
+          },
+          {
+            "slug": "props",
+            "depth": 2,
+            "value": "Props"
+          },
+          {
+            "slug": "usage",
+            "depth": 2,
+            "value": "Usage"
+          }
+        ]
+      }
+    },
+    {
+      "key": "docs/UseTracktor.mdx",
+      "value": {
+        "name": "useTracktor()",
+        "id": "830591f9b63d4cefe7a0ea863f9d496e",
+        "filepath": "docs/UseTracktor.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/UseTracktor.mdx",
+        "slug": "docs-use-tracktor",
+        "route": "/docs-use-tracktor",
+        "menu": "",
+        "headings": [
+          {
+            "slug": "usetracktor-",
+            "depth": 1,
+            "value": "useTracktor()  🎣"
+          },
+          {
+            "slug": "props",
+            "depth": 2,
+            "value": "Props"
+          },
+          {
+            "slug": "props-1",
+            "depth": 3,
+            "value": "Props"
+          },
+          {
+            "slug": "returns",
+            "depth": 3,
+            "value": "Returns"
+          },
+          {
+            "slug": "usage",
+            "depth": 2,
+            "value": "Usage"
+          }
+        ]
+      }
+    },
+    {
+      "key": "docs/index.mdx",
+      "value": {
+        "name": "react-tracktor",
+        "route": "/",
+        "id": "73498ad0e1e62a714b08085d318f9de1",
+        "filepath": "docs/index.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/index.mdx",
+        "slug": "docs-index",
+        "menu": "",
+        "headings": [
+          {
+            "slug": "react-tracktor-",
+            "depth": 1,
+            "value": "react-tracktor 🚜"
+          },
+          {
+            "slug": "caveats",
+            "depth": 2,
+            "value": "Caveats"
+          },
+          {
+            "slug": "installation",
+            "depth": 2,
+            "value": "Installation"
           }
         ]
       }

--- a/.docz/app/db.json
+++ b/.docz/app/db.json
@@ -3,7 +3,7 @@
     "title": "react-tracktor 🚜",
     "description": "A React render prop to gradually build tracking data down the render tree.",
     "menu": [],
-    "version": "1.0.2",
+    "version": "1.0.3",
     "repository": "https://github.com/mkaradeniz/react-tracktor",
     "native": false,
     "codeSandbox": false,
@@ -191,32 +191,16 @@
       }
     },
     {
-      "key": "docs/TracktorProvider.mdx",
+      "key": "docs/UseTracktor.mdx",
       "value": {
-        "name": "<TracktorProvider />",
-        "id": "47f8aae2c3aa6a63cde34d0a3a71f57f",
-        "filepath": "docs/TracktorProvider.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/TracktorProvider.mdx",
-        "slug": "docs-tracktor-provider",
-        "route": "/docs-tracktor-provider",
+        "name": "useTracktor()",
+        "id": "830591f9b63d4cefe7a0ea863f9d496e",
+        "filepath": "docs/UseTracktor.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/UseTracktor.mdx",
+        "slug": "docs-use-tracktor",
+        "route": "/docs-use-tracktor",
         "menu": "",
-        "headings": [
-          {
-            "slug": "tracktorprovider-",
-            "depth": 1,
-            "value": "<TracktorProvider />"
-          },
-          {
-            "slug": "props",
-            "depth": 2,
-            "value": "Props"
-          },
-          {
-            "slug": "usage",
-            "depth": 2,
-            "value": "Usage"
-          }
-        ]
+        "headings": []
       }
     },
     {
@@ -244,6 +228,35 @@
             "slug": "installation",
             "depth": 2,
             "value": "Installation"
+          }
+        ]
+      }
+    },
+    {
+      "key": "docs/TracktorProvider.mdx",
+      "value": {
+        "name": "<TracktorProvider />",
+        "id": "47f8aae2c3aa6a63cde34d0a3a71f57f",
+        "filepath": "docs/TracktorProvider.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/TracktorProvider.mdx",
+        "slug": "docs-tracktor-provider",
+        "route": "/docs-tracktor-provider",
+        "menu": "",
+        "headings": [
+          {
+            "slug": "tracktorprovider-",
+            "depth": 1,
+            "value": "<TracktorProvider />"
+          },
+          {
+            "slug": "props",
+            "depth": 2,
+            "value": "Props"
+          },
+          {
+            "slug": "usage",
+            "depth": 2,
+            "value": "Usage"
           }
         ]
       }

--- a/.docz/app/db.json
+++ b/.docz/app/db.json
@@ -3,7 +3,7 @@
     "title": "react-tracktor 🚜",
     "description": "A React render prop to gradually build tracking data down the render tree.",
     "menu": [],
-    "version": "1.0.3",
+    "version": "2.0.0-0",
     "repository": "https://github.com/mkaradeniz/react-tracktor",
     "native": false,
     "codeSandbox": false,
@@ -78,13 +78,13 @@
                 "name": "IntersectionOptions | undefined"
               }
             },
-            "render": {
+            "pageViewData": {
               "defaultValue": null,
               "description": "",
-              "name": "render",
-              "required": true,
+              "name": "pageViewData",
+              "required": false,
               "type": {
-                "name": "(value: TracktorRenderProp) => ReactNode"
+                "name": "object | undefined"
               }
             },
             "trackingData": {
@@ -127,6 +127,77 @@
             "slug": "usage",
             "depth": 2,
             "value": "Usage"
+          }
+        ]
+      }
+    },
+    {
+      "key": "docs/TracktorProvider.mdx",
+      "value": {
+        "name": "<TracktorProvider />",
+        "id": "47f8aae2c3aa6a63cde34d0a3a71f57f",
+        "filepath": "docs/TracktorProvider.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/TracktorProvider.mdx",
+        "slug": "docs-tracktor-provider",
+        "route": "/docs-tracktor-provider",
+        "menu": "",
+        "headings": [
+          {
+            "slug": "tracktorprovider-",
+            "depth": 1,
+            "value": "<TracktorProvider />"
+          },
+          {
+            "slug": "props",
+            "depth": 2,
+            "value": "Props"
+          },
+          {
+            "slug": "usage",
+            "depth": 2,
+            "value": "Usage"
+          }
+        ]
+      }
+    },
+    {
+      "key": "docs/UseTracktor.mdx",
+      "value": {
+        "name": "useTracktor()",
+        "id": "830591f9b63d4cefe7a0ea863f9d496e",
+        "filepath": "docs/UseTracktor.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/UseTracktor.mdx",
+        "slug": "docs-use-tracktor",
+        "route": "/docs-use-tracktor",
+        "menu": "",
+        "headings": []
+      }
+    },
+    {
+      "key": "docs/index.mdx",
+      "value": {
+        "name": "react-tracktor",
+        "route": "/",
+        "id": "73498ad0e1e62a714b08085d318f9de1",
+        "filepath": "docs/index.mdx",
+        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/index.mdx",
+        "slug": "docs-index",
+        "menu": "",
+        "headings": [
+          {
+            "slug": "react-tracktor-",
+            "depth": 1,
+            "value": "react-tracktor 🚜"
+          },
+          {
+            "slug": "caveats",
+            "depth": 2,
+            "value": "Caveats"
+          },
+          {
+            "slug": "installation",
+            "depth": 2,
+            "value": "Installation"
           }
         ]
       }
@@ -186,77 +257,6 @@
             "slug": "intersectionwrapper",
             "depth": 3,
             "value": "intersectionWrapper"
-          }
-        ]
-      }
-    },
-    {
-      "key": "docs/UseTracktor.mdx",
-      "value": {
-        "name": "useTracktor()",
-        "id": "830591f9b63d4cefe7a0ea863f9d496e",
-        "filepath": "docs/UseTracktor.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/UseTracktor.mdx",
-        "slug": "docs-use-tracktor",
-        "route": "/docs-use-tracktor",
-        "menu": "",
-        "headings": []
-      }
-    },
-    {
-      "key": "docs/index.mdx",
-      "value": {
-        "name": "react-tracktor",
-        "route": "/",
-        "id": "73498ad0e1e62a714b08085d318f9de1",
-        "filepath": "docs/index.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/index.mdx",
-        "slug": "docs-index",
-        "menu": "",
-        "headings": [
-          {
-            "slug": "react-tracktor-",
-            "depth": 1,
-            "value": "react-tracktor 🚜"
-          },
-          {
-            "slug": "caveats",
-            "depth": 2,
-            "value": "Caveats"
-          },
-          {
-            "slug": "installation",
-            "depth": 2,
-            "value": "Installation"
-          }
-        ]
-      }
-    },
-    {
-      "key": "docs/TracktorProvider.mdx",
-      "value": {
-        "name": "<TracktorProvider />",
-        "id": "47f8aae2c3aa6a63cde34d0a3a71f57f",
-        "filepath": "docs/TracktorProvider.mdx",
-        "link": "https://github.com/mkaradeniz/react-tracktor/edit/master/docs/TracktorProvider.mdx",
-        "slug": "docs-tracktor-provider",
-        "route": "/docs-tracktor-provider",
-        "menu": "",
-        "headings": [
-          {
-            "slug": "tracktorprovider-",
-            "depth": 1,
-            "value": "<TracktorProvider />"
-          },
-          {
-            "slug": "props",
-            "depth": 2,
-            "value": "Props"
-          },
-          {
-            "slug": "usage",
-            "depth": 2,
-            "value": "Usage"
           }
         ]
       }

--- a/.docz/app/imports.js
+++ b/.docz/app/imports.js
@@ -7,12 +7,16 @@ export const imports = {
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-tracktor" */ 'docs/Tracktor.mdx'
     ),
-  'docs/TracktorProvider.mdx': () =>
+  'docs/UseTracktor.mdx': () =>
     import(
-      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor-provider" */ 'docs/TracktorProvider.mdx'
+      /* webpackPrefetch: true, webpackChunkName: "docs-use-tracktor" */ 'docs/UseTracktor.mdx'
     ),
   'docs/index.mdx': () =>
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-index" */ 'docs/index.mdx'
+    ),
+  'docs/TracktorProvider.mdx': () =>
+    import(
+      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor-provider" */ 'docs/TracktorProvider.mdx'
     ),
 }

--- a/.docz/app/imports.js
+++ b/.docz/app/imports.js
@@ -3,6 +3,10 @@ export const imports = {
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-page-view" */ 'docs/PageView.mdx'
     ),
+  'docs/Tracktor.mdx': () =>
+    import(
+      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor" */ 'docs/Tracktor.mdx'
+    ),
   'docs/TracktorProvider.mdx': () =>
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-tracktor-provider" */ 'docs/TracktorProvider.mdx'
@@ -14,9 +18,5 @@ export const imports = {
   'docs/index.mdx': () =>
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-index" */ 'docs/index.mdx'
-    ),
-  'docs/Tracktor.mdx': () =>
-    import(
-      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor" */ 'docs/Tracktor.mdx'
     ),
 }

--- a/.docz/app/imports.js
+++ b/.docz/app/imports.js
@@ -3,9 +3,9 @@ export const imports = {
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-page-view" */ 'docs/PageView.mdx'
     ),
-  'docs/Tracktor.mdx': () =>
+  'docs/TracktorProvider.mdx': () =>
     import(
-      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor" */ 'docs/Tracktor.mdx'
+      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor-provider" */ 'docs/TracktorProvider.mdx'
     ),
   'docs/UseTracktor.mdx': () =>
     import(
@@ -15,8 +15,8 @@ export const imports = {
     import(
       /* webpackPrefetch: true, webpackChunkName: "docs-index" */ 'docs/index.mdx'
     ),
-  'docs/TracktorProvider.mdx': () =>
+  'docs/Tracktor.mdx': () =>
     import(
-      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor-provider" */ 'docs/TracktorProvider.mdx'
+      /* webpackPrefetch: true, webpackChunkName: "docs-tracktor" */ 'docs/Tracktor.mdx'
     ),
 }

--- a/.docz/app/root.jsx
+++ b/.docz/app/root.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
-import { Link, Router, Routes } from 'docz'
-
+import { Link, Router, Routes, useDataServer } from 'docz'
+import { hot } from 'react-hot-loader'
 import Theme from 'docz-theme-default'
 
 import { imports } from './imports'
 import database from './db.json'
 
 const Root = () => {
+  useDataServer('ws://127.0.0.1:60505')
   return (
     <Theme linkComponent={Link} db={database}>
       <Routes imports={imports} />
@@ -14,4 +15,4 @@ const Root = () => {
   )
 }
 
-export default Root
+export default hot(module)(Root)

--- a/README.md
+++ b/README.md
@@ -29,29 +29,25 @@ npm install react-tracktor
 import { Tracktor, TracktorProvider } from 'react-tracktor';
 
 <TracktorProvider dispatcher={trackingData => console.log(trackingData)}>
-  <Tracktor
-    trackingData={{ page: 'README.md' }}
-    render={() => (
-      <main>
-        <h2>README.md</h2>
+  <Tracktor trackingData={{ page: 'README.md' }}>
+    <main>
+      <h2>README.md</h2>
 
-        <Tracktor
-          trackingData={{ section: 'example' }}
-          render={({ trackEvent }) => (
-            <section>
-              <h3>
-                <code>trackEvent</code>
-              </h3>
+      <Tracktor trackingData={{ section: 'example' }}>
+        {({ trackEvent }) => (
+          <section>
+            <h3>
+              <code>trackEvent</code>
+            </h3>
 
-              <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
+            <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
 
-              <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
-            </section>
-          )}
-        />
-      </main>
-    )}
-  />
+            <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
+          </section>
+        )}
+      </Tracktor>
+    </main>
+  </Tracktor>
 </TracktorProvider>;
 ```
 
@@ -76,21 +72,45 @@ At each point at the render tree data from all `<Tracktor />` render props above
 
 ##### `<Tracktor />` Props
 
-| Name                  | Type                                       | Default                 | Description                                                                                                                                                                                                 |
-| --------------------- | ------------------------------------------ | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eventData`           | _object_                                   | `{}`                    | An object with tracking data that should be provided to the `dispatcher` when the `onClickWrapper` is fired or (when using the `intersectionRef` or `intersectionWrapper`) the component scrolls into view. |
-| `intersectionOptions` | _object_                                   | `{ triggerOnce: true }` | Options passed to the IntersectionObserver. <br/>See: https://github.com/thebuilder/react-intersection-observer#options                                                                                     |
-| `render`              | `(value: TracktorRenderProp) => ReactNode` | _required_              | The render function                                                                                                                                                                                         |
-| `trackingData`        | _object_                                   | `{}`                    | An object with data that should be used when tracking events from this component and all components further down the render tree.                                                                           |
+| Name                  | Type                                                      | Default                 | Description                                                                                                                                                                                                 |
+| --------------------- | --------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`            | _ReactNode_ \| `(value: TracktorRenderProp) => ReactNode` | _required_              | If `children` is a function, it will act as a render prop that will be called with the content of `TracktorRenderProp`. If it's not a function, it will render the children.                                |
+| `eventData`           | _object_                                                  | `{}`                    | An object with tracking data that should be provided to the `dispatcher` when the `onClickWrapper` is fired or (when using the `intersectionRef` or `intersectionWrapper`) the component scrolls into view. |
+| `intersectionOptions` | _object_                                                  | `{ triggerOnce: true }` | Options passed to the IntersectionObserver. <br/>See: https://github.com/thebuilder/react-intersection-observer#options                                                                                     |
+| `trackingData`        | _object_                                                  | `{}`                    | An object with data that should be used when tracking events from this component and all components further down the render tree.                                                                           |
 
 ##### `render` Props
 
-| Name                  | Type                                          | Description                                                                                                                                  |
-| --------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `intersectionRef`     | _ReactRef_                                    | If used as a ref for a DOM element, a `trackEvent` will be fired with the the provided `eventData` when the refed element scrolls into view. |
-| `intersectionWrapper` | `(WrappedComponent: ReactNode) => ReactNode)` | Can be used to wrap a component to inject an invisibile `<div />` which will have the `intersectionRef` and track on intersection.           |
-| `onClickWrapper`      | `(trackEventData: object) => () => void`      | Can be used to wrap a component's `onClick` prop, the returning function, also fires an `trackEvent`.                                        |
-| `trackEvent`          | `(trackEventData: object) => void`            | Function which fires an `trackEvent` with the provided data, merged with all previously provided `trackingData`.                             |
+| Name                  | Type                                          | Description                                                                                                                                                                      |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createTrackEvent`    | `(trackEventData: object) => () => void`      | Higher-order-function to create a `trackEvent` function. Normally used in `onClick` props. Example: `<button onClick={createTrackEvent({ hello: 'world' })}>Click Me</button>}>` |
+| `intersectionRef`     | _ReactRef_                                    | If used as a ref for a DOM element, a `trackEvent` will be fired with the the provided `eventData` when the refed element scrolls into view.                                     |
+| `intersectionWrapper` | `(WrappedComponent: ReactNode) => ReactNode)` | Can be used to wrap a component to inject an invisibile `<div />` which will have the `intersectionRef` and track on intersection.                                               |
+| `onClickWrapper`      | `(trackEventData: object) => () => void`      | Can be used to wrap a component's `onClick` prop, the returning function, also fires an `trackEvent`.                                                                            |
+| `trackEvent`          | `(trackEventData: object) => void`            | Function which fires an `trackEvent` with the provided data, merged with all previously provided `trackingData`.                                                                 |
+
+### `useTracktor()` 🎣
+
+Since hooks can't provide context, `useTracktor()` is not a complete alternative to `<Tracktor />`, but provides the same functions as `<Tracktor />`'s render prop. It can also be provided with `pageViewData` to track page views. See `<Tracktor />` & `<PageView />` for more information.
+
+#### Props
+
+| Name                  | Type     | Default                 | Description                                                                                                                                                                                                 |
+| --------------------- | -------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eventData`           | _object_ | `{}`                    | An object with tracking data that should be provided to the `dispatcher` when the `onClickWrapper` is fired or (when using the `intersectionRef` or `intersectionWrapper`) the component scrolls into view. |
+| `intersectionOptions` | _object_ | `{ triggerOnce: true }` | Options passed to the IntersectionObserver. <br/>See: https://github.com/thebuilder/react-intersection-observer#options                                                                                     |
+| `pageViewData`        | _object_ | `undefined`             | An object with data that the `dispatcher` should be called with on page load.                                                                                                                               |
+| `trackingData`        | _object_ | `{}`                    | An object with data that should be used when tracking events from this component and all components further down the render tree.                                                                           |
+
+#### Returns
+
+| Name                  | Type                                          | Description                                                                                                                                                                      |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createTrackEvent`    | `(trackEventData: object) => () => void`      | Higher-order-function to create a `trackEvent` function. Normally used in `onClick` props. Example: `<button onClick={createTrackEvent({ hello: 'world' })}>Click Me</button>}>` |
+| `intersectionRef`     | _ReactRef_                                    | If used as a ref for a DOM element, a `trackEvent` will be fired with the the provided `eventData` when the refed element scrolls into view.                                     |
+| `intersectionWrapper` | `(WrappedComponent: ReactNode) => ReactNode)` | Can be used to wrap a component to inject an invisibile `<div />` which will have the `intersectionRef` and track on intersection.                                               |
+| `onClickWrapper`      | `(trackEventData: object) => () => void`      | Can be used to wrap a component's `onClick` prop, the returning function, also fires an `trackEvent`.                                                                            |
+| `trackEvent`          | `(trackEventData: object) => void`            | Function which fires an `trackEvent` with the provided data, merged with all previously provided `trackingData`.                                                                 |
 
 ### `<PageView />`
 

--- a/docs/UseTracktor.mdx
+++ b/docs/UseTracktor.mdx
@@ -1,0 +1,36 @@
+---
+name: useTracktor()
+---
+
+import { Playground } from 'docz';
+
+import Tracktor from '../src/Tracktor';
+import Test from '../src/Test';
+import TracktorProvider from '../src/TracktorProvider';
+
+<Playground>
+  <TracktorProvider dispatcher={trackingData => console.log(trackingData)}>
+    <Tracktor
+      trackingData={{ page: 'Tracktor.mdx' }}
+      render={() => (
+        <main>
+          <h2>Tracktor.mdx</h2>
+          <Tracktor trackingData={{ section: 'basic_usage' }}
+            render={({ trackEvent }) => (
+              <section>
+                <Test/>
+
+                <h3><code>trackEvent</code></h3>
+
+                <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
+
+                <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
+              </section>
+            )}
+          />
+        </main>
+      )}
+    />
+
+  </TracktorProvider>
+</Playground>

--- a/docs/UseTracktor.mdx
+++ b/docs/UseTracktor.mdx
@@ -10,27 +10,25 @@ import TracktorProvider from '../src/TracktorProvider';
 
 <Playground>
   <TracktorProvider dispatcher={trackingData => console.log(trackingData)}>
-    <Tracktor
-      trackingData={{ page: 'Tracktor.mdx' }}
-      render={() => (
-        <main>
-          <h2>Tracktor.mdx</h2>
-          <Tracktor trackingData={{ section: 'basic_usage' }}
-            render={({ trackEvent }) => (
-              <section>
-                <Test/>
+    <Tracktor trackingData={{ page: 'Tracktor.mdx' }}>
+      <main>
+        <h2>Tracktor.mdx</h2>
 
-                <h3><code>trackEvent</code></h3>
+        <Tracktor trackingData={{ section: 'basic_usage' }}>
+          {({ trackEvent }) => (
+            <section>
+              <Test/>
 
-                <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
+              <h3><code>trackEvent</code></h3>
 
-                <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
-              </section>
-            )}
-          />
-        </main>
-      )}
-    />
+              <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
+
+              <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
+            </section>
+          )}
+        </Tracktor>
+      </main>
+    </Tracktor>
 
   </TracktorProvider>
 </Playground>

--- a/docs/UseTracktor.mdx
+++ b/docs/UseTracktor.mdx
@@ -5,30 +5,58 @@ name: useTracktor()
 import { Playground } from 'docz';
 
 import Tracktor from '../src/Tracktor';
-import Test from '../src/Test';
 import TracktorProvider from '../src/TracktorProvider';
+import useTracktor from '../src/useTracktor';
 
-<Playground>
-  <TracktorProvider dispatcher={trackingData => console.log(trackingData)}>
+# `useTracktor()` 🎣
+
+Since hooks can't provide context, `useTracktor()` is not a complete alternative to `<Tracktor />`, but provides the same functions as `<Tracktor />`'s render prop. It can also be provided with `pageViewData` to track page views. See `<Tracktor />` & `<PageView />` for more information.
+
+## Props
+
+### Props
+
+| Name                  | Type     | Default                 | Description                                                                                                                                                                                                 |
+| --------------------- | -------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eventData`           | _object_ | `{}`                    | An object with tracking data that should be provided to the `dispatcher` when the `onClickWrapper` is fired or (when using the `intersectionRef` or `intersectionWrapper`) the component scrolls into view. |
+| `intersectionOptions` | _object_ | `{ triggerOnce: true }` | Options passed to the IntersectionObserver. <br/>See: https://github.com/thebuilder/react-intersection-observer#options                                                                                     |
+| `pageViewData`        | _object_ | `undefined`             | An object with data that the `dispatcher` should be called with on page load.                                                                                                                               |
+| `trackingData`        | _object_ | `{}`                    | An object with data that should be used when tracking events from this component and all components further down the render tree.                                                                           |
+
+### Returns
+
+| Name                  | Type                                          | Description                                                                                                                                                                      |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createTrackEvent`    | `(trackEventData: object) => () => void`      | Higher-order-function to create a `trackEvent` function. Normally used in `onClick` props. Example: `<button onClick={createTrackEvent({ hello: 'world' })}>Click Me</button>}>` |
+| `intersectionRef`     | _ReactRef_                                    | If used as a ref for a DOM element, a `trackEvent` will be fired with the the provided `eventData` when the refed element scrolls into view.                                     |
+| `intersectionWrapper` | `(WrappedComponent: ReactNode) => ReactNode)` | Can be used to wrap a component to inject an invisibile `<div />` which will have the `intersectionRef` and track on intersection.                                               |
+| `onClickWrapper`      | `(trackEventData: object) => () => void`      | Can be used to wrap a component's `onClick` prop, the returning function, also fires an `trackEvent`.                                                                            |
+| `trackEvent`          | `(trackEventData: object) => void`            | Function which fires an `trackEvent` with the provided data, merged with all previously provided `trackingData`.                                                                 |
+
+## Usage
+
+```typescript
+const MyComponent = () => {
+  const { trackEvent } = useTracktor({ pageViewData: { hello: 'world' } });
+
+  return (
     <Tracktor trackingData={{ page: 'Tracktor.mdx' }}>
       <main>
         <h2>Tracktor.mdx</h2>
 
         <Tracktor trackingData={{ section: 'basic_usage' }}>
-          {({ trackEvent }) => (
-            <section>
-              <Test/>
+          <section>
+            <h3>
+              <code>trackEvent</code>
+            </h3>
 
-              <h3><code>trackEvent</code></h3>
+            <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
 
-              <button onClick={() => trackEvent({ button: 'hello' })}>Hello</button>
-
-              <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
-            </section>
-          )}
+            <button onClick={() => trackEvent({ button: 'goodbye' })}>Goodbye</button>
+          </section>
         </Tracktor>
       </main>
     </Tracktor>
-
-  </TracktorProvider>
-</Playground>
+  );
+};
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tracktor",
-  "version": "1.0.3",
+  "version": "2.0.0-0",
   "author": "Max Karadeniz <max@karadeniz.io> (http://karadeniz.io/)",
   "description": "A React render prop to gradually build tracking data down the render tree.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tracktor",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "author": "Max Karadeniz <max@karadeniz.io> (http://karadeniz.io/)",
   "description": "A React render prop to gradually build tracking data down the render tree.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tracktor",
-  "version": "2.0.0-1",
+  "version": "2.0.0",
   "author": "Max Karadeniz <max@karadeniz.io> (http://karadeniz.io/)",
   "description": "A React render prop to gradually build tracking data down the render tree.",
   "keywords": [

--- a/src/PageView.tsx
+++ b/src/PageView.tsx
@@ -1,34 +1,12 @@
-import React from 'react';
-
-import { TracktorContext, initialState } from './TracktorContext';
+import useTracktor from './useTracktor';
 
 // Types
-import { ContextType, PageViewProps } from './types';
+import { PageViewProps } from './types';
 
 const PageView = ({ pageViewData }: PageViewProps) => {
-  // We want to copy the context data, so we can use it from outside the `TracktorContext.Consumer` render prop.
-  const [copiedContext, setCopiedContext] = React.useState<ContextType>(initialState);
+  useTracktor({ pageViewData });
 
-  React.useEffect(() => {
-    if (!!pageViewData && !copiedContext.dispatcher.isDefault) {
-      // Get the `dispatcher` out of the context and call it with the provided `pageViewData`.
-      const { dispatcher } = copiedContext;
-
-      dispatcher(pageViewData);
-    }
-  }, [copiedContext.dispatcher.isDefault]);
-
-  return (
-    // We take the current context, copy it, and forward it to the next `<Tracktor />` with the data from this component merged.
-    // This enables us to gradually build the tracking object and have only the appropriate data at each level.
-    <TracktorContext.Consumer>
-      {context => {
-        setCopiedContext(context);
-
-        return null;
-      }}
-    </TracktorContext.Consumer>
-  );
+  return null;
 };
 
 export default PageView;

--- a/src/Test.tsx
+++ b/src/Test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import useTracktor from './useTracktor';
+
+const Test = () => {
+  const { trackEvent } = useTracktor({ pageViewData: { pageView: 'useTracktor()' } });
+
+  return <button onClick={() => trackEvent({ hello: 'fromTest' })}>Hello</button>;
+};
+
+export default Test;

--- a/src/Tracktor.tsx
+++ b/src/Tracktor.tsx
@@ -1,62 +1,21 @@
 import React from 'react';
 
-import IntersectionComponent from './IntersectionComponent';
 import computeTrackingData from './utils/computeTrackingData';
-import useOnIntersect from './utils/useOnIntersect';
-import wrapFunction from './utils/wrapFunction';
+import useTracktor from './useTracktor';
 import { TracktorContext, initialState } from './TracktorContext';
 
 // Types
-import { ContextType, TrackingData, TrackEventOptions, TracktorProps } from './types';
-import { ReactNode } from 'react';
+import { ContextType, TracktorProps } from './types';
 
 const Tracktor = ({ eventData, intersectionOptions = { triggerOnce: true }, render, trackingData: ownData = {} }: TracktorProps) => {
   // We want to copy the context data, so we can use it from outside the `TracktorContext.Consumer` render prop.
-  const [copiedContext, setCopiedContext] = React.useState<ContextType>(initialState);
+  const [, setCopiedContext] = React.useState<ContextType>(initialState);
 
-  // Gets the `dispatcher` out of the context, computes the tracking data, and calls it.
-  const trackEvent = (trackEventData: TrackingData = {}, options: TrackEventOptions = {}) => {
-    const { dispatcher } = copiedContext;
-    const { withoutContext } = options;
-
-    if (withoutContext) {
-      return dispatcher(trackEventData);
-    }
-
-    const computedTrackingData = computeTrackingData(copiedContext.data, ownData, trackEventData || {});
-
-    dispatcher(computedTrackingData);
-  };
-
-  // This higher-order function sets the `trackEventData` and also checks whether the library-consumer
-  // defined the `eventData` which is used inside this function.
-  const createOnClickWrapperFunction = (trackEventData: TrackingData = {}) => () => {
-    if (!eventData && process.env.NODE_ENV !== 'production') {
-      throw new Error('If the `onClickWrapper` is used, the `eventData` prop has to be defined.');
-    }
-
-    trackEvent(trackEventData || {});
-  };
-
-  // This enables the consumer to wrap a component's `onClick` prop to also fire the tracking event.
-  const onClickWrapper = wrapFunction(createOnClickWrapperFunction(eventData));
-
-  // Will be called when consumer puts the `ref` on a component and it scrolls into view.
-  const handleIntersection = () => {
-    if (!eventData && process.env.NODE_ENV !== 'production') {
-      throw new Error('If the `intersectionRef` is used, the `eventData` prop has to be defined.');
-    }
-
-    trackEvent(eventData || {});
-  };
-
-  const [intersectionRef] = useOnIntersect({ callback: handleIntersection, options: intersectionOptions });
-
-  // This function can be called with the elements the consumer wants to render and it will inject a
-  // invsibile `<div />` with the `intersectionRef` into the DOM.
-  const intersectionWrapper = (wrappedComponent: ReactNode) => (
-    <IntersectionComponent ref={intersectionRef}>{wrappedComponent}</IntersectionComponent>
-  );
+  const { intersectionRef, intersectionWrapper, onClickWrapper, trackEvent } = useTracktor({
+    eventData,
+    intersectionOptions,
+    trackingData: ownData,
+  });
 
   return (
     // We take the current context, copy it, and forward it to the next `<Tracktor />` with the data from this component merged.

--- a/src/Tracktor.tsx
+++ b/src/Tracktor.tsx
@@ -7,7 +7,7 @@ import { TracktorContext, initialState } from './TracktorContext';
 // Types
 import { ContextType, TracktorProps } from './types';
 
-const Tracktor = ({ eventData, intersectionOptions = { triggerOnce: true }, render, trackingData: ownData = {} }: TracktorProps) => {
+const Tracktor = ({ children, eventData, intersectionOptions = { triggerOnce: true }, trackingData: ownData = {} }: TracktorProps) => {
   // We want to copy the context data, so we can use it from outside the `TracktorContext.Consumer` render prop.
   const [, setCopiedContext] = React.useState<ContextType>(initialState);
 
@@ -19,18 +19,23 @@ const Tracktor = ({ eventData, intersectionOptions = { triggerOnce: true }, rend
 
   return (
     // We take the current context, copy it, and forward it to the next `<Tracktor />` with the data from this component merged.
-    // This enables us to gradually build the tracking object and have only the appropriate data at each level..
+    // This enables us to gradually build the tracking object and have only the appropriate data at each level.
     <TracktorContext.Consumer>
       {context => {
         setCopiedContext(context);
 
         const nextContextValue = { ...context, data: computeTrackingData(context.data, ownData) };
 
-        return (
-          <TracktorContext.Provider value={nextContextValue}>
-            {render({ intersectionRef, intersectionWrapper, onClickWrapper, trackEvent })}
-          </TracktorContext.Provider>
-        );
+        if (typeof children === 'function') {
+          // `children` is a function, call it with the provided functions from `useTracktor`.
+          return (
+            <TracktorContext.Provider value={nextContextValue}>
+              {children({ intersectionRef, intersectionWrapper, onClickWrapper, trackEvent })}
+            </TracktorContext.Provider>
+          );
+        }
+
+        return <TracktorContext.Provider value={nextContextValue}>{children}</TracktorContext.Provider>;
       }}
     </TracktorContext.Consumer>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 export * from './types';
 
+export { TracktorContext } from './TracktorContext';
 export { default as PageView } from './PageView';
-export { default as TracktorProvider } from './TracktorProvider';
 export { default as Tracktor } from './Tracktor';
+export { default as TracktorProvider } from './TracktorProvider';
+export { default as useTracktor } from './useTracktor';

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,11 +25,11 @@ export type TrackEventOptions = {
 export type TrackingData = object;
 
 export type TracktorProps = {
+  children: ((value: TracktorRenderProp) => ReactNode) | ReactNode;
   eventData?: TrackingData;
   intersectionOptions?: IntersectionOptions;
-  render: (value: TracktorRenderProp) => ReactNode;
-  trackingData?: TrackingData;
   pageViewData?: TrackingData;
+  trackingData?: TrackingData;
 };
 
 export type UseTracktorProps = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,14 @@ export type TracktorProps = {
   intersectionOptions?: IntersectionOptions;
   render: (value: TracktorRenderProp) => ReactNode;
   trackingData?: TrackingData;
+  pageViewData?: TrackingData;
+};
+
+export type UseTracktorProps = {
+  eventData?: TrackingData;
+  intersectionOptions?: IntersectionOptions;
+  pageViewData?: TrackingData;
+  trackingData?: TrackingData;
 };
 
 export type TracktorProviderProps = {

--- a/src/useTracktor.tsx
+++ b/src/useTracktor.tsx
@@ -7,8 +7,8 @@ import wrapFunction from './utils/wrapFunction';
 import { TracktorContext } from './TracktorContext';
 
 // Types
-import { TrackingData, TrackEventOptions, UseTracktorProps } from './types';
 import { ReactNode } from 'react';
+import { TrackingData, TrackEventOptions, UseTracktorProps } from './types';
 
 const useTracktor = ({
   eventData,

--- a/src/useTracktor.tsx
+++ b/src/useTracktor.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import IntersectionComponent from './IntersectionComponent';
+import computeTrackingData from './utils/computeTrackingData';
+import useOnIntersect from './utils/useOnIntersect';
+import wrapFunction from './utils/wrapFunction';
+import { TracktorContext } from './TracktorContext';
+
+// Types
+import { TrackingData, TrackEventOptions, UseTracktorProps } from './types';
+import { ReactNode } from 'react';
+
+const useTracktor = ({
+  eventData,
+  intersectionOptions = { triggerOnce: true },
+  pageViewData,
+  trackingData: ownData = {},
+}: UseTracktorProps) => {
+  const { data, dispatcher } = React.useContext(TracktorContext);
+
+  React.useEffect(() => {
+    if (!!pageViewData && !dispatcher.isDefault) {
+      // Get the `dispatcher` out of the context and call it with the provided `pageViewData`.
+
+      dispatcher(pageViewData);
+    }
+  }, [dispatcher.isDefault]);
+
+  // Gets the `dispatcher` out of the context, computes the tracking data, and calls it.
+  const trackEvent = (trackEventData: TrackingData = {}, options: TrackEventOptions = {}) => {
+    const { withoutContext } = options;
+
+    if (withoutContext) {
+      return dispatcher(trackEventData);
+    }
+
+    const computedTrackingData = computeTrackingData(data, ownData, trackEventData || {});
+
+    dispatcher(computedTrackingData);
+  };
+
+  // This higher-order function sets the `trackEventData` and also checks whether the library-consumer
+  // defined the `eventData` which is used inside this function.
+  const createOnClickWrapperFunction = (trackEventData: TrackingData = {}) => () => {
+    if (!eventData && process.env.NODE_ENV !== 'production') {
+      throw new Error('If the `onClickWrapper` is used, the `eventData` prop has to be defined.');
+    }
+
+    trackEvent(trackEventData || {});
+  };
+
+  // This enables the consumer to wrap a component's `onClick` prop to also fire the tracking event.
+  const onClickWrapper = wrapFunction(createOnClickWrapperFunction(eventData));
+
+  // Will be called when consumer puts the `ref` on a component and it scrolls into view.
+  const handleIntersection = () => {
+    if (!eventData && process.env.NODE_ENV !== 'production') {
+      throw new Error('If the `intersectionRef` is used, the `eventData` prop has to be defined.');
+    }
+
+    trackEvent(eventData || {});
+  };
+
+  const [intersectionRef] = useOnIntersect({ callback: handleIntersection, options: intersectionOptions });
+
+  // This function can be called with the elements the consumer wants to render and it will inject a
+  // invsibile `<div />` with the `intersectionRef` into the DOM.
+  const intersectionWrapper = (wrappedComponent: ReactNode) => (
+    <IntersectionComponent ref={intersectionRef}>{wrappedComponent}</IntersectionComponent>
+  );
+
+  return { intersectionRef, intersectionWrapper, onClickWrapper, trackEvent };
+};
+
+export default useTracktor;

--- a/src/useTracktor.tsx
+++ b/src/useTracktor.tsx
@@ -16,17 +16,17 @@ const useTracktor = ({
   pageViewData,
   trackingData: ownData = {},
 }: UseTracktorProps) => {
+  // Get the built `trackingData` and the `dispatcher` from our context.
   const { data, dispatcher } = React.useContext(TracktorContext);
 
   React.useEffect(() => {
     if (!!pageViewData && !dispatcher.isDefault) {
-      // Get the `dispatcher` out of the context and call it with the provided `pageViewData`.
-
+      // Call the `dispatcher` with the provided `pageViewData`.
       dispatcher(pageViewData);
     }
-  }, [dispatcher.isDefault]);
+  }, []);
 
-  // Gets the `dispatcher` out of the context, computes the tracking data, and calls it.
+  // Computes the tracking data, and calls the `dispatcher` with it.
   const trackEvent = (trackEventData: TrackingData = {}, options: TrackEventOptions = {}) => {
     const { withoutContext } = options;
 
@@ -41,7 +41,7 @@ const useTracktor = ({
 
   // This higher-order function sets the `trackEventData` and also checks whether the library-consumer
   // defined the `eventData` which is used inside this function.
-  const createOnClickWrapperFunction = (trackEventData: TrackingData = {}) => () => {
+  const createTrackEvent = (trackEventData: TrackingData = {}) => () => {
     if (!eventData && process.env.NODE_ENV !== 'production') {
       throw new Error('If the `onClickWrapper` is used, the `eventData` prop has to be defined.');
     }
@@ -50,7 +50,7 @@ const useTracktor = ({
   };
 
   // This enables the consumer to wrap a component's `onClick` prop to also fire the tracking event.
-  const onClickWrapper = wrapFunction(createOnClickWrapperFunction(eventData));
+  const onClickWrapper = wrapFunction(createTrackEvent(eventData));
 
   // Will be called when consumer puts the `ref` on a component and it scrolls into view.
   const handleIntersection = () => {
@@ -69,7 +69,7 @@ const useTracktor = ({
     <IntersectionComponent ref={intersectionRef}>{wrappedComponent}</IntersectionComponent>
   );
 
-  return { intersectionRef, intersectionWrapper, onClickWrapper, trackEvent };
+  return { createTrackEvent, intersectionRef, intersectionWrapper, onClickWrapper, trackEvent };
 };
 
 export default useTracktor;


### PR DESCRIPTION
- Introduce new `useTracktor()` hook.
- `<Tracktor />` 
  - **Breaking Change**: Removed `render` prop. Instead takes either `children` as `ReactNode`s and renders them, or a function as `children` and calls it with same functions as the `render` prop.